### PR TITLE
Trigger docs build automatically

### DIFF
--- a/.github/workflows/rsync-docs.yml
+++ b/.github/workflows/rsync-docs.yml
@@ -1,22 +1,19 @@
 # Publish the static Sphinx build on Trading Strategy server using rsync
-
 name: Docs build
 
 on:
   push:
     branches: [ master ]
+  workflow_dispatch:
+
 jobs:
   rsync-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      # We need to use HTTPS checkout on CI
       - name: Fetch submodules
-        run: |
-          git submodule set-url deps/furo https://github.com/tradingstrategy-ai/furo.git
-          git submodule set-url deps/trade-executor https://github.com/tradingstrategy-ai/trade-executor.git 
-          git submodule update --init --recursive
+        run: make install-deps
       - name: Install poetry
         run: pipx install poetry
       - name: Set up Python 3.9
@@ -27,7 +24,8 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          sudo apt-get install -y pandoc
+          sudo apt update
+          sudo apt install -y pandoc
           poetry env use '3.9'
           poetry install -vv
       - name: Build documentation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,37 @@
+name: Test docs build
+
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  test-docs-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: Fetch submodules
+        run: make install-deps
+      - name: Install poetry
+        run: pipx install poetry
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v3
+        # If caches were enabled, it was caching Python 3.8 interpreter
+        # causing the docs build to fails
+        with:
+          python-version: 3.9
+      - name: Install dependencies
+        run: |
+          sudo apt-get install -y pandoc
+          poetry env use '3.9'
+          poetry install -vv
+      - name: Build documentation
+        run: |        
+          poetry env use '3.9'
+          python -V
+          which python
+          echo $PATH
+          PYTHON=`poetry env info -p`/bin/python
+          SPHINX=`poetry env info -p`/bin/sphinx-build
+          make install-furo 
+          make rebuild-furo html

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,7 +22,8 @@ jobs:
           python-version: 3.9
       - name: Install dependencies
         run: |
-          sudo apt-get install -y pandoc
+          sudo apt update
+          sudo apt install -y pandoc
           poetry env use '3.9'
           poetry install -vv
       - name: Build documentation

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "deps/furo"]
 	path = deps/furo
-	url = git@github.com:tradingstrategy-ai/furo.git
+	url = https://github.com/tradingstrategy-ai/furo.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,9 +1,3 @@
-[submodule "deps/trading-strategy"]
-	path = deps/trading-strategy
-	url = https://github.com/tradingstrategy-ai/trading-strategy.git
-[submodule "deps/trade-executor"]
-	path = deps/trade-executor
-	url = git@github.com:tradingstrategy-ai/trade-executor.git
 [submodule "deps/furo"]
 	path = deps/furo
 	url = git@github.com:tradingstrategy-ai/furo.git

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,11 @@ help:
 browser-docs-macos:
 	open build/html/index.html
 
+# Fetch submodules
+install-deps:
+	git submodule update --init --recursive
+	git clone --recursive https://github.com/tradingstrategy-ai/trade-executor.git deps/trade-executor
+
 # Get Webpack tool chain to build Furo theme
 install-furo:
 	(cd deps/furo && npm install)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ View [the documentation here](https://tradingstrategy.ai/docs).
 To build everything from the scratch: 
 
 ```shell
-git submodule update --init --recursive 
+make install-deps
 poetry shell
 poetry install
 make install-furo rebuild-furo clean-autosummary clean html

--- a/scripts/update-deps.sh
+++ b/scripts/update-deps.sh
@@ -6,4 +6,3 @@
 set -e
 
 (cd deps/furo && git pull origin main)
-(cd deps/trade-executor && git pull origin master)


### PR DESCRIPTION
Change `trade-executor` from submodule to be cloned during installation process to make sure we have latest master during build process.
Then allow the build process to be triggered by another repo