### PR TITLE
Adjust sample EMA strategy notebook

### DIFF
--- a/source/programming/strategy-examples/pancakeswap-ema.ipynb
+++ b/source/programming/strategy-examples/pancakeswap-ema.ipynb
@@ -98,7 +98,7 @@
     "EXCHANGE_SLUG = \"pancakeswap-v2\"\n",
     "\n",
     "# Which trading pair we are trading\n",
-    "TRADING_PAIR = (\"WBNB\", \"BUSD\")   # TODOO: namedtuple?\n",
+    "TRADING_PAIR = (\"WBNB\", \"BUSD\")\n",
     "\n",
     "# How much of the cash to put on a single trade\n",
     "POSITION_SIZE = 0.10\n",


### PR DESCRIPTION
The strategy is modified to reflect what @tsorro has come up with, apart from the fact that it uses 4h candles instead of 2h candles. This is for performance reasons, as using 1h candles takes a bit too much time and several users might give up on it before the backtesting finishes.