### PR TITLE
change slippage references to price impact

### DIFF
--- a/source/programming/code-examples/price-impact.ipynb
+++ b/source/programming/code-examples/price-impact.ipynb
@@ -11,9 +11,9 @@
    "source": [
     "# Price impact estimation\n",
     "\n",
-    "In this notebook, we show how you can estimate the price impact, also known as slippage, of the simulated historical decentralised exchange trades.\n",
+    "In this notebook, we show how you can estimate the price impact of the simulated historical decentralised exchange trades.\n",
     "\n",
-    "The slippage is especially important when trading illiquid assets. If your trade profit is 2% but the sell slippage is also 2% you have essentially not made any profit."
+    "The price impact is especially important when trading illiquid assets. If your trade profit is 2% but the price impact is also 2% you have essentially not made any profit."
    ]
   },
   {
@@ -25,21 +25,23 @@
     }
    },
    "source": [
-    "## About price impact and slippage on AMMs\n",
+    "## About price impact on AMMs\n",
     "\n",
-    "The slippage is a function of\n",
+    "The price impact is a function of\n",
     "\n",
     "* Available liquidity\n",
     "* Liquidity provider fees\n",
     "* Protocol fees\n",
     "\n",
-    "Slippage, also known as price impact, tells how much less your market taker order gets filled because there is not available liquidity.\n",
-    "For example, if you are trying to buy 5000 USD worth of BNB token, but there isn't available liquidity\n",
-    "you end up with 4980 USD worth of token at the end of the trade. The missing fill is called slippage.\n",
-    "It can be expressed as USD value or as percent of the trade amount.\n",
-    "Illiquid pairs have more slippage than liquid pairs.\n",
+    "Price impact indicates how much your market taker order loses in value due to insufficient liquidity.\n",
+    "For example, if you are trying to buy 5000 USD worth of BNB token in a low liquidity pair and \n",
+    "you end up with 4980 USD worth of token at the end of the trade, the loss in value due to low liquidity is called price impact.\n",
+    "This can be expressed as USD value or as percent of the trade amount.\n",
+    "Illiquid pairs higher price impact than liquid pairs.\n",
     "\n",
-    "In Uniswap v2 style decentralised exchanges any fees are included in the slippage calculation.\n",
+    "Be careful not to confuse price impact and slippage. Slippage refers to a loss in value due to external trades in the same pair being executed by other users before yours and changing the relative prices of the assets in the pair.  \n",
+    "\n",
+    "In Uniswap v2 style decentralised exchanges any fees are included in the price impact calculation.\n",
     "\n",
     "To understand the liquidity better, [you can interactively view the available liquidity to any trading pair on Trading Strategy website](https://tradingstrategy.ai/trading-view/trading-pairs).\n",
     "\n",


### PR DESCRIPTION
doc currently conflates slippage and price impact. This PR fixes that.