### PR TITLE
Fix typo in glossary.rst

### DIFF
--- a/source/glossary.rst
+++ b/source/glossary.rst
@@ -3852,7 +3852,7 @@ and algorithmic trading.
 
         - Wallets (query tokens, balances)
 
-        - Decentralised appliaction frontends
+        - Decentralised application frontends
 
         You can get a JSON-RPC API for your blockchain application by
 


### PR DESCRIPTION
This pull request addresses a minor but noticeable typographical error in the codebase. The word "appliaction" has been corrected to "application" throughout the affected files. This fix enhances the accuracy and professionalism of our codebase and user-facing content.