### PR TITLE
Update to not crawl genindex.html

### DIFF
--- a/scraper/config.json
+++ b/scraper/config.json
@@ -6,7 +6,9 @@
     "sitemap_urls": [
       "https://tradingstrategy.ai/docs/sitemap-docs.xml"
     ],
-    "stop_urls": [],
+    "stop_urls": [
+      "https://tradingstrategy.ai/docs/genindex.html"
+    ],
     "selectors": {
       "lvl0": {
         "selector": "",


### PR DESCRIPTION
I add ```stop_urls``` to  ```https://tradingstrategy.ai/docs/genindex.html```
Typesense DocSearch Scraper will skip this URL