### PR TITLE
Update vault data schema docs

### DIFF
--- a/source/overview/defi-vault-data.rst
+++ b/source/overview/defi-vault-data.rst
@@ -8,14 +8,244 @@ Vault datasets are
 1. Vault metadata and real-time summaries
 2. Historical returns data
 
+Access plans and files
+----------------------
+
+See the `Trading Strategy vault data pricing page <https://tradingstrategy.ai/pricing>`__
+for the current Free and Pro plan terms.
+
+The downloadable dataset files are listed on the
+`Vault datasets page <https://tradingstrategy.ai/trading-view/vaults/datasets>`__.
+
++--------------------------------------+-------------------------------+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| File                                 | Plan                          | Format                | Description                                                                                                                        |
++======================================+===============================+=======================+====================================================================================================================================+
+| ``vault-metadata.sample.json``       | Free                          | JSON                  | Limited sample of vault metadata covering only Ethereum vaults. Uses the same vault metadata schema as the Pro file.               |
++--------------------------------------+-------------------------------+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``vault-historical.sample.parquet``  | Free                          | Parquet               | Limited sample of historical price/TVL data covering only Ethereum vaults. Uses the same historical schema as the Pro file.        |
++--------------------------------------+-------------------------------+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``vault-metadata.json``              | Professional / Pro            | JSON                  | Full tracked vault metadata and metric summary file for paid subscribers.                                                          |
++--------------------------------------+-------------------------------+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``vault-historical.parquet``         | Professional / Pro            | Parquet               | Full tracked vault historical share price, TVL and state file for paid subscribers.                                                |
++--------------------------------------+-------------------------------+-----------------------+------------------------------------------------------------------------------------------------------------------------------------+
+
+The schema descriptions below apply to both Free sample files and Professional / Pro full files.
+The difference is dataset coverage and access control, not the column or field meaning.
+
+How to download
+---------------
+
+Download links and ``curl`` examples are available on the
+`Vault datasets download page <https://tradingstrategy.ai/trading-view/vaults/datasets#download-with-curl>`__.
+
+Professional / Pro downloads require an API key. Free sample files can be downloaded
+from the same dataset catalogue.
+
+Example data analysis
+---------------------
+
+This section is intended for LLMs and automation agents as a set of concrete examples
+for extracting vault data from the downloaded files. The examples assume only basic
+Python packages are installed: Pandas with Parquet reading support, plus Python's
+standard library.
+
+Use ``vault-metadata.json`` and ``vault-historical.parquet`` for Professional / Pro
+analysis. For the Free plan, use ``vault-metadata.sample.json`` and
+``vault-historical.sample.parquet``; the code is the same, but the sample files only
+cover Ethereum vaults.
+
+Load the files
+~~~~~~~~~~~~~~
+
+.. code-block:: python
+
+    import json
+    from pathlib import Path
+
+    import pandas as pd
+
+    data_dir = Path(".")
+
+    metadata_path = data_dir / "vault-metadata.json"
+    historical_path = data_dir / "vault-historical.parquet"
+
+    with metadata_path.open("r", encoding="utf-8") as f:
+        metadata = json.load(f)
+
+    vaults = pd.DataFrame(metadata["vaults"])
+    prices = pd.read_parquet(historical_path)
+
+    if "timestamp" in prices.columns:
+        prices["timestamp"] = pd.to_datetime(prices["timestamp"])
+
+Get all USDC-denominated vaults
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Use ``normalised_denomination`` for token-symbol filtering, because wrapped or
+bridged token symbols may be normalised to a canonical symbol.
+
+.. code-block:: python
+
+    usdc_vaults = vaults[
+        vaults["normalised_denomination"].str.upper().eq("USDC")
+    ].copy()
+
+    cols = [
+        "name",
+        "chain",
+        "protocol",
+        "curator_name",
+        "current_nav",
+        "three_months_cagr",
+        "trading_strategy_link",
+    ]
+
+    usdc_vaults = usdc_vaults.sort_values("current_nav", ascending=False)
+    print(usdc_vaults[cols].head(25).to_string(index=False))
+
+Chart historical returns for a Spark vault
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example finds the largest Spark vault by current TVL, loads its historical
+share price series, converts it to cumulative returns, and displays it as a chart.
+
+.. code-block:: python
+
+    spark_vaults = vaults[
+        vaults["protocol"].str.contains("Spark", case=False, na=False)
+        | vaults["name"].str.contains("Spark", case=False, na=False)
+    ].copy()
+
+    spark_vaults = spark_vaults.sort_values("current_nav", ascending=False)
+    spark = spark_vaults.iloc[0]
+
+    spark_prices = prices[prices["id"].eq(spark["id"])].copy()
+    spark_prices = spark_prices.sort_values("timestamp")
+
+    spark_prices["returns"] = (
+        spark_prices["share_price"] / spark_prices["share_price"].iloc[0] - 1.0
+    )
+
+    ax = spark_prices.plot(
+        x="timestamp",
+        y="returns",
+        title=f"{spark['name']} cumulative return",
+        grid=True,
+    )
+    ax.set_ylabel("Return")
+
+Get all Gauntlet-curated vaults
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example lists vaults curated by Gauntlet, sorted by 3-month annualised return.
+``trading_strategy_link`` is the Trading Strategy vault page URL.
+
+.. code-block:: python
+
+    gauntlet = vaults[
+        vaults["curator_slug"].eq("gauntlet")
+        | vaults["curator_name"].str.contains("Gauntlet", case=False, na=False)
+    ].copy()
+
+    table = gauntlet[
+        [
+            "name",
+            "chain",
+            "trading_strategy_link",
+            "current_nav",
+            "three_months_cagr",
+        ]
+    ].rename(
+        columns={
+            "trading_strategy_link": "link",
+            "current_nav": "current_tvl",
+            "three_months_cagr": "three_months_annualised_return",
+        }
+    )
+
+    table = table.sort_values(
+        "three_months_annualised_return",
+        ascending=False,
+        na_position="last",
+    )
+
+    print(table.to_string(index=False))
+
+30-day return correlation for top Hyperliquid Hypercore vaults
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+This example selects the top 10 Hypercore vaults by TVL, with a minimum TVL of
+2,000,000 USD, then calculates a 30-day correlation matrix from daily returns.
+Hypercore native vaults use synthetic chain id ``9999``.
+
+.. code-block:: python
+
+    hypercore = vaults[
+        vaults["chain_id"].eq(9999)
+        & vaults["current_nav"].ge(2_000_000)
+    ].copy()
+
+    top_hypercore = hypercore.sort_values(
+        "current_nav",
+        ascending=False,
+    ).head(10)
+
+    top_ids = top_hypercore["id"].tolist()
+
+    hp = prices[prices["id"].isin(top_ids)].copy()
+    hp = hp.sort_values(["id", "timestamp"])
+
+    daily_share_price = (
+        hp.pivot_table(
+            index="timestamp",
+            columns="id",
+            values="share_price",
+            aggfunc="last",
+        )
+        .resample("D")
+        .last()
+        .ffill()
+    )
+
+    daily_returns = daily_share_price.pct_change().tail(30)
+    corr = daily_returns.corr()
+
+    id_to_name = top_hypercore.set_index("id")["name"].to_dict()
+    corr = corr.rename(index=id_to_name, columns=id_to_name)
+
+    print(corr.round(3).to_string())
+
 Vault metadata format
 ---------------------
 
-The vault metadata contains descriptions of all vaults. 
+The vault metadata schema applies to both ``vault-metadata.sample.json`` and
+``vault-metadata.json``. The sample file has limited Ethereum-only coverage; the
+Professional / Pro file contains the full tracked dataset.
+
+The vault metadata contains descriptions of all vaults.
 
 The vault metadata is served as a JSON file.
 
-The field descriptions:
+The top-level JSON object has the following shape:
+
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Key                                  | Description                                                                                                                        |
++======================================+====================================================================================================================================+
+| ``generated_at``                     | ISO 8601 UTC timestamp when the export was generated.                                                                              |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``metadata``                         | Export provenance metadata. Currently contains ``version`` with ``tag``, ``commit_message`` and ``commit_hash`` of the exporter.   |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``core3_protocols``                  | Core3 protocol risk intelligence keyed by protocol slug. Only protocols present in exported vaults are included.                   |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``curators``                         | Curator metadata keyed by curator slug. Includes identity fields, logo URLs and recent feed entries when available.                |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``vaults``                           | List of per-vault metric records documented below.                                                                                 |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+
+The ``metadata.version`` fields may be ``null`` when the exporter runs outside a Docker image
+that was stamped with git version information.
+
+Per-vault field descriptions:
 
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | Key                                  | Label                     | Description                                                                                                                        |
@@ -35,7 +265,11 @@ The field descriptions:
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``share_token_address``              | Share Token Address       | On‑chain address of the vault’s ERC‑20 share token. Usually the vault contract address itself.                                     |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``share_token_decimals``             | Share Token Decimals      | ERC‑20 decimals of the vault share token. Do not default a missing value to 18.                                                    |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``denomination_token_address``       | Denomination Token Addr.  | On‑chain address of the denomination (underlying) token.                                                                           |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``denomination_decimals``            | Denomination Decimals     | ERC‑20 decimals of the denomination token. Needed for converting human token amounts to raw integer amounts.                       |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``lifetime_return``                  | Lifetime Return (Gross)   | All‑time gross return from first to last price as a decimal fraction (e.g., 0.10 = 10%).                                           |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
@@ -85,7 +319,11 @@ The field descriptions:
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``mgmt_fee``                         | Management Fee            | Annual management fee as a decimal (e.g., 0.02 = 2%). May be missing if not detected.                                              |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``management_fee``                   | Management Fee Alias      | JSON compatibility alias for ``mgmt_fee``.                                                                                         |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``perf_fee``                         | Performance Fee           | Performance fee as a decimal (e.g., 0.20 = 20% of profits). May be missing if not detected.                                        |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``performance_fee``                  | Performance Fee Alias     | JSON compatibility alias for ``perf_fee``.                                                                                         |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``deposit_fee``                      | Deposit Fee               | Fee applied on deposits as a decimal (e.g., 0.01 = 1%). May be null if no fee.                                                     |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
@@ -94,6 +332,10 @@ The field descriptions:
 | ``fee_mode``                         | Fee Mode                  | How fees are applied: ``externalised`` (charged at deposit/withdraw) or ``internalised`` (deducted from NAV).                      |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``fee_internalised``                 | Fee Internalised          | Boolean shorthand: ``true`` if fees are deducted from NAV (share price already reflects fees).                                     |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``gross_fees``                       | Gross Fee Structure       | Fee object before protocol-specific net-fee adjustments. Contains management, performance, deposit and withdrawal fee fields.      |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``net_fees``                         | Net Fee Structure         | Investor-visible fee object after protocol-specific adjustments.                                                                   |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``fee_label``                        | Fee Label                 | Human‑readable fee summary, e.g., ``2% / 20%`` or including deposit/withdrawal fees if present.                                    |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
@@ -106,6 +348,8 @@ The field descriptions:
 | ``risk``                             | Risk (Category)           | Technical risk classification object; renderable to a human label via its API.                                                     |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``risk_numeric``                     | Risk (Numeric)            | Numeric representation of the technical risk category for sorting or filtering.                                                    |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``vault_poll_frequency``             | Poll Frequency            | Latest adaptive vault scan cycle or poll frequency, e.g. ``large_tvl``, ``peaked``, ``1h``, ``4h`` or ``24h``.                     |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``id``                               | Vault ID                  | Unique identifier combining chain and address (``<chainId>-<address>``). Can be used as a stable primary key.                      |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
@@ -128,6 +372,24 @@ The field descriptions:
 | ``last_updated_block``               | Last Updated Block        | Block number corresponding to the latest recorded observation.                                                                     |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``last_share_price``                 | Last Share Price          | Most recent share price observation in the denomination currency.                                                                  |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``one_month_start``                  | 1M Sample Start           | Actual timestamp of the first sample used for the legacy one-month metrics. ``null`` if unavailable.                               |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``one_month_end``                    | 1M Sample End             | Actual timestamp of the last sample used for the legacy one-month metrics. ``null`` if unavailable.                                |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``one_month_samples``                | 1M Samples                | Number of raw samples used for the legacy one-month metrics.                                                                       |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``three_months_start``               | 3M Sample Start           | Actual timestamp of the first sample used for the legacy three-month metrics. ``null`` if unavailable.                             |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``three_months_end``                 | 3M Sample End             | Actual timestamp of the last sample used for the legacy three-month metrics. ``null`` if unavailable.                              |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``three_months_samples``             | 3M Samples                | Number of raw samples used for the legacy three-month metrics.                                                                     |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``lifetime_start``                   | Lifetime Sample Start     | Actual timestamp of the first sample used for lifetime metrics.                                                                    |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``lifetime_end``                     | Lifetime Sample End       | Actual timestamp of the last sample used for lifetime metrics.                                                                     |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``lifetime_samples``                 | Lifetime Samples          | Number of raw samples used for lifetime metrics.                                                                                   |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``features``                         | Detected Features         | List of detected vault features (e.g., ERC‑4626/7540 capabilities) as feature names.                                               |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
@@ -172,11 +434,29 @@ The field descriptions:
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``manual_review_status``             | Manual Review Status      | Manual review decision (e.g., ``"ok"``, ``"avoid"``). Currently used for Hyperliquid vaults. ``null`` if not reviewed.             |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
-| ``other_data``                       | Protocol Extension Data   | Protocol‑specific extension dict. See `other_data and Morpho flags`_ below. Empty lists for non‑Morpho vaults.                     |
+| ``core3``                            | Core3 Risk Summary        | Compact per-vault Core3 risk summary for the vault protocol, or ``null`` when no Core3 data is available.                          |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``denomination_token_rate``          | Denomination Rate         | Stablecoin rate and depeg metadata for the denomination token. Includes USD rate fields and native/source currency cross-rates.    |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``other_data``                       | Protocol Extension Data   | Protocol‑specific extension dict. See `other_data and Morpho flags`_ below.                                                        |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``period_results``                   | Period Results            | List of `PeriodMetrics <https://web3-ethereum-defi.tradingstrategy.ai/api/research/_autosummary_research/                          |
 |                                      |                           | eth_defi.research.vault_metrics.PeriodMetrics.html>`__ objects for 1W, 1M, 3M, 6M, 1Y, and lifetime windows.                       |
 |                                      |                           | See `Structured period metrics`_ below.                                                                                            |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``first_qualified_at``               | First Qualified At        | Sticky export annotation: first time this vault passed the export filter. Only present on sticky-processed rows.                   |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``last_qualified_at``                | Last Qualified At         | Sticky export annotation: latest time this vault passed the export filter. Only present on sticky-processed rows.                  |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``sticky_export``                    | Sticky Export             | ``true`` when a vault is exported because it previously passed the filter; ``false`` on stale current-row warnings.                |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``stale_export``                     | Stale Export              | ``true`` when a previous successful record is replayed because the current row is missing or structurally unsafe.                  |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``sticky_reason``                    | Sticky Reason             | Reason for sticky inclusion, currently ``previously_passed_filter``. Only present for sticky exports.                              |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``stale_current_row``                | Stale Current Row         | ``true`` when the current row is older than the freshness warning window.                                                          |
++--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``risk_possibly_stale``              | Risk Possibly Stale       | ``true`` when stale source data means risk fields may lag current on-chain state.                                                  |
 +--------------------------------------+---------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 
 Structured period metrics
@@ -199,6 +479,10 @@ Each ``PeriodMetrics`` object contains:
 | ``period_start_at``                  | Timestamp when the period’s start share price was sampled.                                                                         |
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``period_end_at``                    | Timestamp when the period’s end share price was sampled.                                                                           |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``samples_start_at``                 | Actual first raw sample timestamp used for the period. May differ from ``period_start_at`` because samples are sparse.             |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``samples_end_at``                   | Actual last raw sample timestamp used for the period.                                                                              |
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``share_price_start``                | Share price at the beginning of the period.                                                                                        |
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
@@ -250,8 +534,16 @@ blacklisted, have zero/NaN CAGR, or fall below the TVL thresholds.
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``other_data`` field is a protocol‑specific extension dict included in every vault record.
-Currently it is populated only for **Morpho** vaults; all other protocols return empty lists.
-Future protocols should add their own keys here rather than adding top‑level fields.
+It contains generic display warning hints and protocol-specific details. Future protocols should
+add their own keys here rather than adding top‑level fields.
+
+Generic keys:
+
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| Key                                  | Description                                                                                                                        |
++======================================+====================================================================================================================================+
+| ``vault_display_flags``              | UI-friendly warning entries with ``severity``, ``type`` and ``source``. Empty list when no display warnings apply.                 |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 
 The Morpho‑specific keys are sourced from the Morpho Blue API via
 `analyze_morpho_flags() <https://web3-ethereum-defi.tradingstrategy.ai/api/erc_4626/vault_protocol/morpho/_autosummary_morpho/eth_defi.erc_4626.vault_protocol.morpho.flag_analytics.analyze_morpho_flags.html>`__
@@ -282,18 +574,35 @@ flag is added to the ``flags`` set.
 Historical vault data
 ---------------------
 
+The historical vault data schema applies to both ``vault-historical.sample.parquet``
+and ``vault-historical.parquet``. The sample file has limited Ethereum-only coverage;
+the Professional / Pro file contains the full tracked dataset.
+
 Historical vault data is the past performance metrics of a vault.
 
 - TVL
 - Total supply (as in the share token count)
 - Returns (also known as :term:`CAGR`, :term:`APY`)
 
-Historical data is served as a compressed Parquet file.
+Historical data is served as a compressed Parquet file. The pipeline has two related schemas:
+
+- Raw scanner rows are written to ``vault-prices-1h.parquet`` using the canonical
+  ``VaultHistoricalRead.to_pyarrow_schema()`` columns.
+- The published historical dataset is the cleaned/enriched Parquet output. It keeps the
+  raw scanner columns, preserves native protocol extension columns, adds metadata columns
+  such as ``id`` and ``protocol``, and computes return columns such as ``returns_1h``.
+
+When both ``share_price`` and ``raw_share_price`` are present, use ``share_price`` for
+analytics. ``raw_share_price`` preserves the original scanner/API value before cleaning
+and outlier fixes.
 
 General columns (all protocols)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-These columns are present for every vault regardless of protocol.
+These columns are present for every vault in the published cleaned dataset. Some columns
+(``id``, ``name``, ``event_count``, ``protocol``, ``returns_1h``, ``deposit_closed_reason``
+and ``raw_share_price``) are added by the cleaning pipeline and are not part of the raw
+EVM scanner writer schema.
 
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | Column                               | Description                                                                                                                        |
@@ -309,6 +618,8 @@ These columns are present for every vault regardless of protocol.
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``share_price``                      | Share price in denomination token units. Read from contract for ERC-4626; from API for GRVT, Lighter, Hibachi;                     |
 |                                      | internally calculated for Hypercore (see note below).                                                                              |
++--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
+| ``raw_share_price``                  | Original share price before cleaning/outlier adjustments. Use ``share_price`` for analytics.                                       |
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+
 | ``total_assets``                     | Total assets under management (TVL) in denomination token units.                                                                   |
 +--------------------------------------+------------------------------------------------------------------------------------------------------------------------------------+


### PR DESCRIPTION
## Summary
- document Free and Pro vault data files and download links
- refresh vault metadata JSON schema notes
- clarify historical Parquet raw vs cleaned schema
- add Pandas examples for common vault data analysis tasks

## Validation
- git diff --check
- RST grid-table boundary check

Note: full Sphinx build was not run locally because the Poetry docs environment is blocked by Python/package setup issues.