### PR TITLE
fix: quote argument-hint YAML values so Copilot CLI ≥1.0.65 loads all skills (closes #88)

### DIFF
--- a/.claude/skills/add-book/SKILL.md
+++ b/.claude/skills/add-book/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: add-book
 description: Add a new book to the documentation collection. Use when user provides a URL to a book page or tweet linking to one.
-argument-hint: [url]
+argument-hint: "[url]"
 ---
 
 # Add new book

--- a/.claude/skills/add-code-repository/SKILL.md
+++ b/.claude/skills/add-code-repository/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: add-code-repository
 description: Add a new code repository to the documentation collection. Use when user provides a URL to a GitHub, GitLab, Bitbucket, source repository, or a discussion linking to one.
-argument-hint: [url]
+argument-hint: "[url]"
 ---
 
 # Add code repository

--- a/.claude/skills/add-post/SKILL.md
+++ b/.claude/skills/add-post/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: add-post
 description: Add a new blog post or article to the documentation collection. Use when user provides a URL to a blog post, article, or tweet linking to one.
-argument-hint: [url]
+argument-hint: "[url]"
 ---
 
 # Add new blog post


### PR DESCRIPTION
Closes #88.

## Summary

Purely mechanical single-character transform to 3 file(s): wrap the value after `argument-hint:` in double quotes so YAML parses it as a **string** instead of a flow-sequence array. Fixes GitHub Copilot CLI ≥ 1.0.65 silently dropping the skill.

```diff
- argument-hint: [foo]
+ argument-hint: "[foo]"
```

Bare `[...]` is YAML flow-sequence syntax → the loader receives `["foo"]` (a list), fails its `str` validation, and rejects the SKILL without an error. Claude Code, VS Code Agent Skills, and every other loader document `argument-hint` as a string; the quoted-string form is what all reference docs show.

## Files (3)

- `.claude/skills/add-book/SKILL.md`
- `.claude/skills/add-post/SKILL.md`
- `.claude/skills/add-code-repository/SKILL.md`

## Verification

- YAML round-trip via `yaml.safe_load` on every changed frontmatter reports `argument-hint` as `str`
- No vulnerable value contained `"` or `\`, so bare double-quote wrapping is safe

## Sources

- [Claude Code slash-commands / frontmatter reference](https://code.claude.com/docs/en/slash-commands) — `argument-hint` documented as a string
- [VS Code Agent Skills docs](https://code.visualstudio.com/docs/agent-customization/agent-skills) — same
